### PR TITLE
Pin @remix-run/router to patched 1.23.2 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
+  "overrides": {
+    "@remix-run/router": "1.23.2"
+  },
   "packages": {
     "": {
       "name": "ref-land",
@@ -23,6 +26,9 @@
         "react-plx": "^2.1.2",
         "react-router-dom": "^6.12.0",
         "vite-plugin-eslint": "^1.8.1"
+      },
+      "overrides": {
+        "@remix-run/router": "1.23.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "react-router-dom": "^6.12.0",
     "vite-plugin-eslint": "^1.8.1"
   },
+  "overrides": {
+    "@remix-run/router": "1.23.2"
+  },
   "devDependencies": {
     "@types/react": "^18.2.9",
     "@types/react-dom": "^18.2.4",


### PR DESCRIPTION
### Motivation
- Patch a security issue (GHSA-2w69-qvjg-hvjx) related to unsafe open navigation redirects in `@remix-run/router` by forcing the patched version `1.23.2`.
- The project may pull the vulnerable router transitively, so an explicit override is required to ensure the patched code is used.

### Description
- Add an `overrides` entry to `package.json` that pins `@remix-run/router` to `1.23.2` using `"@remix-run/router": "1.23.2"`.
- Reflect the same `overrides` metadata in `package-lock.json` so installers honor the forced version.
- Modified files: `package.json` and `package-lock.json` and no other source code was changed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69634ab3cf188324963b1ef1abe4e09e)