### PR TITLE
Pin `minimatch` across dependencies via package overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,43 @@
   "requires": true,
   "overrides": {
     "@remix-run/router": "1.23.2",
-    "tar": "6.2.2"
+    "tar": "6.2.2",
+    "@eslint/eslintrc": {
+      "minimatch": "3.1.4"
+    },
+    "@humanwhocodes/config-array": {
+      "minimatch": "3.1.4"
+    },
+    "eslint": {
+      "minimatch": "3.1.4"
+    },
+    "eslint-plugin-react": {
+      "minimatch": "3.1.4"
+    },
+    "glob": {
+      "minimatch": "3.1.4"
+    },
+    "@tufjs/models": {
+      "minimatch": "9.0.7"
+    },
+    "ignore-walk": {
+      "minimatch": "9.0.7"
+    },
+    "glob@10": {
+      "minimatch": "9.0.7"
+    },
+    "glob@8": {
+      "minimatch": "5.1.8"
+    },
+    "npm-check-updates": {
+      "minimatch": "9.0.7"
+    },
+    "read-package-json": {
+      "minimatch": "9.0.7"
+    },
+    "make-fetch-happen": {
+      "minimatch": "5.1.8"
+    }
   },
   "packages": {
     "": {
@@ -30,7 +66,43 @@
       },
       "overrides": {
         "@remix-run/router": "1.23.2",
-        "tar": "6.2.2"
+        "tar": "6.2.2",
+        "@eslint/eslintrc": {
+          "minimatch": "3.1.4"
+        },
+        "@humanwhocodes/config-array": {
+          "minimatch": "3.1.4"
+        },
+        "eslint": {
+          "minimatch": "3.1.4"
+        },
+        "eslint-plugin-react": {
+          "minimatch": "3.1.4"
+        },
+        "glob": {
+          "minimatch": "3.1.4"
+        },
+        "@tufjs/models": {
+          "minimatch": "9.0.7"
+        },
+        "ignore-walk": {
+          "minimatch": "9.0.7"
+        },
+        "glob@10": {
+          "minimatch": "9.0.7"
+        },
+        "glob@8": {
+          "minimatch": "5.1.8"
+        },
+        "npm-check-updates": {
+          "minimatch": "9.0.7"
+        },
+        "read-package-json": {
+          "minimatch": "9.0.7"
+        },
+        "make-fetch-happen": {
+          "minimatch": "5.1.8"
+        }
       },
       "devDependencies": {
         "@types/react": "^18.2.9",
@@ -2057,7 +2129,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "minimatch": "3.1.4",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2106,7 +2178,7 @@
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
+        "minimatch": "3.1.4"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -2631,7 +2703,7 @@
       "integrity": "sha512-qaGV9ltJP0EO25YfFUPhxRVK0evXFIAGicsVXuRim4Ed9cjPxYhNnNJ49SFmbeLgtxpslIkX317IgpfcHPVj/A==",
       "dependencies": {
         "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^9.0.0"
+        "minimatch": "9.0.7"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2646,9 +2718,8 @@
       }
     },
     "node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3245,7 +3316,7 @@
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
+        "minimatch": "9.0.7",
         "minipass": "^5.0.0 || ^6.0.2",
         "path-scurry": "^1.7.0"
       },
@@ -3268,9 +3339,8 @@
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3977,7 +4047,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "3.1.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "strip-ansi": "^6.0.1",
@@ -4006,7 +4076,7 @@
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
+        "minimatch": "3.1.4",
         "object.entries": "^1.1.6",
         "object.fromentries": "^2.0.6",
         "object.hasown": "^1.1.2",
@@ -4700,7 +4770,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "3.1.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -5027,7 +5097,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
       "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
       "dependencies": {
-        "minimatch": "^9.0.0"
+        "minimatch": "9.0.7"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5042,9 +5112,8 @@
       }
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5811,7 +5880,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^5.0.1",
+        "minimatch": "5.1.8",
         "once": "^1.3.0"
       },
       "engines": {
@@ -5830,9 +5899,8 @@
       }
     },
     "node_modules/make-fetch-happen/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5932,9 +6000,8 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6336,7 +6403,7 @@
         "json-parse-helpfulerror": "^1.0.3",
         "jsonlines": "^0.1.1",
         "lodash": "^4.17.21",
-        "minimatch": "^9.0.0",
+        "minimatch": "9.0.7",
         "p-map": "^4.0.0",
         "pacote": "15.1.1",
         "parse-github-url": "^1.0.2",
@@ -6403,7 +6470,7 @@
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
+        "minimatch": "9.0.7",
         "minipass": "^5.0.0 || ^6.0.2",
         "path-scurry": "^1.7.0"
       },
@@ -6437,9 +6504,8 @@
       }
     },
     "node_modules/npm-check-updates/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -7584,7 +7650,7 @@
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
+        "minimatch": "9.0.7",
         "minipass": "^5.0.0 || ^6.0.2",
         "path-scurry": "^1.7.0"
       },
@@ -7607,9 +7673,8 @@
       }
     },
     "node_modules/read-package-json/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,43 @@
   },
   "overrides": {
     "@remix-run/router": "1.23.2",
-    "tar": "6.2.2"
+    "tar": "6.2.2",
+    "@eslint/eslintrc": {
+      "minimatch": "3.1.4"
+    },
+    "@humanwhocodes/config-array": {
+      "minimatch": "3.1.4"
+    },
+    "eslint": {
+      "minimatch": "3.1.4"
+    },
+    "eslint-plugin-react": {
+      "minimatch": "3.1.4"
+    },
+    "glob": {
+      "minimatch": "3.1.4"
+    },
+    "@tufjs/models": {
+      "minimatch": "9.0.7"
+    },
+    "ignore-walk": {
+      "minimatch": "9.0.7"
+    },
+    "glob@10": {
+      "minimatch": "9.0.7"
+    },
+    "glob@8": {
+      "minimatch": "5.1.8"
+    },
+    "npm-check-updates": {
+      "minimatch": "9.0.7"
+    },
+    "read-package-json": {
+      "minimatch": "9.0.7"
+    },
+    "make-fetch-happen": {
+      "minimatch": "5.1.8"
+    }
   },
   "devDependencies": {
     "@types/react": "^18.2.9",


### PR DESCRIPTION
### Motivation
- Prevent inconsistent or vulnerable `minimatch` versions in the dependency tree by forcing specific, patched releases across transitive dependencies.

### Description
- Add `overrides` entries in `package.json` to pin `minimatch` versions for multiple packages and package ranges (notably `3.1.4`, `5.1.8`, and `9.0.7`).
- Update `package-lock.json` to reflect the pinned `minimatch` versions and to update affected lockfile entries (including `@tufjs/models`, `glob`, `make-fetch-happen`, `npm-check-updates`, `read-package-json`, and others).
- Replace loose `minimatch` ranges in the lockfile with the specified exact versions and update resolved entries for the `minimatch` packages.

### Testing
- Ran `npm ci` to install using the updated lockfile and the command completed successfully.
- Ran the project build with `npm run build` (`vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9fafe3054832491b82a07e517d47f)